### PR TITLE
feat: address.ip() supports node 18

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 sudo: false
 language: node_js
 node_js:
+  - '18'
+  - '16'
+  - '14'
   - '12'
   - '10'
   - '8'

--- a/lib/address.js
+++ b/lib/address.js
@@ -24,6 +24,19 @@ function getIfconfigCMD() {
   return '/sbin/ifconfig';
 }
 
+// typeof os.networkInterfaces family is a number (v18.0.0)
+// types: 'IPv4' | 'IPv6' => 4 | 6
+// @see https://github.com/nodejs/node/issues/42861
+function matchName(actualFamily, expectedFamily) {
+  if (expectedFamily === 'IPv4') {
+    return actualFamily === 'IPv4' || actualFamily === 4;
+  }
+  if (expectedFamily === 'IPv6') {
+    return actualFamily === 'IPv6' || actualFamily === 6;
+  }
+  return actualFamily === expectedFamily;
+}
+
 /**
  * Get all addresses.
  *
@@ -65,7 +78,7 @@ address.interface = function (family, name) {
     if (items) {
       for (var j = 0; j < items.length; j++) {
         var item = items[j];
-        if (item.family === family) {
+        if (matchName(item.family, family)) {
           return item;
         }
       }
@@ -78,7 +91,7 @@ address.interface = function (family, name) {
       var items = interfaces[k];
       for (var i = 0; i < items.length; i++) {
         var item = items[i];
-        if (item.family === family && item.address !== '127.0.0.1') {
+        if (matchName(item.family, family) && item.address !== '127.0.0.1') {
           return item;
         }
       }


### PR DESCRIPTION
- typeof os.networkInterfaces family is a number (v18.0.0)

@see https://github.com/nodejs/node/issues/42861