### PR TITLE
test: should return first ethernet addrs

### DIFF
--- a/test/address.test.js
+++ b/test/address.test.js
@@ -31,8 +31,8 @@ describe('test/address.test.js', () => {
       address((err, addr) => {
         assert(!err);
         assert.deepStrictEqual(Object.keys(addr), [ 'ip', 'ipv6', 'mac' ]);
-        assert.match(addr.mac, /^(?:[a-z0-9]{2}\:){5}[a-z0-9]{2}$/i);
-        assert.match(addr.ip, /^\d+\.\d+\.\d+\.\d+$/);
+        addr.mac && assert.match(addr.mac, /^(?:[a-z0-9]{2}\:){5}[a-z0-9]{2}$/i);
+        addr.ip && assert.match(addr.ip, /^\d+\.\d+\.\d+\.\d+$/);
         done();
       });
     });


### PR DESCRIPTION
On Ubuntu's autopkgtest infrastructure, we're seeing a test failure with v1.2.1: https://autopkgtest.ubuntu.com/results/autopkgtest-lunar/lunar/ppc64el/n/node-address/20230419_101818_a5f3b@/log.gz

```
  test/ts.test.js
    undefined should works with ts without error (11330ms)

  19 passing (11s)
  1 pending
  1 failing

  1) test/address.test.js
       address()
         should return first ethernet addrs:
     AssertionError [ERR_ASSERTION]: The "string" argument must be of type string. Received type object (null)
      at /tmp/autopkgtest.RdWSJJ/autopkgtest_tmp/smoke24Z5Wo/test/address.test.js:34:16
      at /usr/share/nodejs/address/lib/address.js:66:5
      at address.mac (/usr/share/nodejs/address/lib/address.js:205:12)
      at address (/usr/share/nodejs/address/lib/address.js:62:11)
      at Context.<anonymous> (test/address.test.js:31:7)
      at callFnAsync (/usr/share/nodejs/mocha/lib/runnable.js:394:21)
      at Runnable.run (/usr/share/nodejs/mocha/lib/runnable.js:338:7)
      at Runner.runTest (/usr/share/nodejs/mocha/lib/runner.js:666:10)
      at /usr/share/nodejs/mocha/lib/runner.js:789:12
      at next (/usr/share/nodejs/mocha/lib/runner.js:581:14)
      at /usr/share/nodejs/mocha/lib/runner.js:591:7
      at next (/usr/share/nodejs/mocha/lib/runner.js:474:14)
      at Immediate._onImmediate (/usr/share/nodejs/mocha/lib/runner.js:559:5)
      at process.processImmediate (node:internal/timers:471:21)

autopkgtest [10:18:06]: test pkg-js-autopkgtest: -----------------------]
autopkgtest [10:18:06]: test pkg-js-autopkgtest:  - - - - - - - - - - results - - - - - - - - - -
pkg-js-autopkgtest   FAIL non-zero exit status 1
```

This seems to be related to the refactoring done in PR #27 where the `addr.mac && ` check got removed:
```diff
-  describe('address()', function () {
-    it('should return first ethernet addrs', function (done) {
-      address(function (err, addr) {
-        should.not.exists(err);
-        addr.should.have.keys('ip', 'ipv6', 'mac');
-        addr.mac && addr.mac.should.match(/^(?:[a-z0-9]{2}\:){5}[a-z0-9]{2}$/i);
-        addr.ip && addr.ip.should.match(/^\d+\.\d+\.\d+\.\d+$/);
+  describe('address()', () => {
+    it('should return first ethernet addrs', done => {
+      address((err, addr) => {
+        assert(!err);
+        assert.deepStrictEqual(Object.keys(addr), [ 'ip', 'ipv6', 'mac' ]);
+        assert.match(addr.mac, /^(?:[a-z0-9]{2}\:){5}[a-z0-9]{2}$/i);
+        assert.match(addr.ip, /^\d+\.\d+\.\d+\.\d+$/);
         done();
```

It's propably happening only on systems where the `loopback` interface is being used, due to a combination of https://github.com/node-modules/address/commit/c316a04 and https://github.com/node-modules/address/issues/6

We're using 127.0.0.1 and 127.0.1.1 on `lo` inside Ubuntu's autopkgtest CI.